### PR TITLE
インターフェイス「IJsonClass」の削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,15 @@ C#でJSON変換を簡単に実装できる簡易ライブラリです。
 
       1. usingの追加します。  
           ```csharp
-          using JsonExtention;
           using JsonExtention.Extentions;
           ```
 
       1. JSON変換したいクラスの定義します。  
-         ※JSON継承用インターフェイス「IJsonClass」を継承します。    
           ```csharp
           /// <summary>
           /// サンプルクラス
           /// </summary>
-          public class WeatherForecast : IJsonClass
+          public class WeatherForecast
           {
             public DateTimeOffset Date { get; set; }
             public int TemperatureCelsius { get; set; }

--- a/src/Example/Program.cs
+++ b/src/Example/Program.cs
@@ -1,12 +1,11 @@
-﻿using JsonExtention;
-using JsonExtention.Extentions;
+﻿using JsonExtention.Extentions;
 
 namespace Example;
 
 /// <summary>
 /// サンプルクラス
 /// </summary>
-public class WeatherForecast : IJsonClass
+public class WeatherForecast
 {
   public DateTimeOffset Date { get; set; }
   public int TemperatureCelsius { get; set; }
@@ -37,7 +36,7 @@ class Program
     Console.WriteLine($"Serialize[{json}]");
 
     // シリアライズしたJSON文字列をデシアライズ
-    var classInstance = json.Deserialize<WeatherForecast>() ?? new WeatherForecast();
+    var classInstance = json.Deserialize<WeatherForecast>();
 
     // デシアライズ結果を表示
     Console.WriteLine($"Deserialize!");

--- a/src/JsonExtentionTest/DeserializeTest.cs
+++ b/src/JsonExtentionTest/DeserializeTest.cs
@@ -1,4 +1,3 @@
-using JsonExtention;
 using JsonExtention.Extentions;
 using JsonExtentionTest.Shared;
 using System;

--- a/src/JsonExtentionTest/SerializeTest.cs
+++ b/src/JsonExtentionTest/SerializeTest.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using JsonExtention;
 using JsonExtention.Extentions;
 using JsonExtentionTest.Shared;
 using System;

--- a/src/JsonExtentionTest/Shared/WeatherForecast.cs
+++ b/src/JsonExtentionTest/Shared/WeatherForecast.cs
@@ -1,5 +1,3 @@
-using JsonExtention;
-using JsonExtention.Extentions;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +6,7 @@ namespace JsonExtentionTest.Shared;
 /// <summary>
 /// テスト用サンプルクラス
 /// </summary>
-public class WeatherForecast : IJsonClass
+public class WeatherForecast
 {
   public DateTimeOffset Date { get; set; }
   public int TemperatureCelsius { get; set; }

--- a/src/JsonExtentionTest/Shared/WeatherForecastNullable.cs
+++ b/src/JsonExtentionTest/Shared/WeatherForecastNullable.cs
@@ -1,5 +1,3 @@
-using JsonExtention;
-using JsonExtention.Extentions;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +6,7 @@ namespace JsonExtentionTest.Shared;
 /// <summary>
 /// テスト用サンプルクラス
 /// </summary>
-public class WeatherForecastNullable : IJsonClass
+public class WeatherForecastNullable
 {
   public DateTimeOffset? Date { get; set; }
   public int? TemperatureCelsius { get; set; }

--- a/src/Lib/JsonExtention/Extentions/JsonExtention.cs
+++ b/src/Lib/JsonExtention/Extentions/JsonExtention.cs
@@ -10,21 +10,20 @@ public static class JsonExtention
   /// <summary>
   /// JSONシリアライズ
   /// </summary>
-  /// <param name="src">JSON継承用インターフェイスのサブクラスインスタンス</param>
+  /// <param name="src">シリアライズ対象のクラスインスタンス</param>
   /// <returns>JSON文字列</returns>
-  static public string Serialize(this IJsonClass src)
+  static public string Serialize<T>(this T src) where T : class
   {
-    var t = src.GetType();
-    return JsonSerializer.Serialize(Convert.ChangeType(src, t));
+    return JsonSerializer.Serialize(src);
   }
 
   /// <summary>
   /// JSONデシアライズ
   /// </summary>
   /// <param name="src">JSON文字列</param>
-  /// <typeparam name="T">JSON継承用インターフェイスのサブクラス</typeparam>
-  /// <returns>JSON継承用インターフェイスのサブクラスインスタンス</returns>
-  static public T Deserialize<T>(this string src) where T : IJsonClass, new()
+  /// <typeparam name="T">デシアライズ用クラス</typeparam>
+  /// <returns>デシアライズ用クラスのインスタンス</returns>
+  static public T Deserialize<T>(this string src) where T : class, new()
   {
     return JsonSerializer.Deserialize<T>(src) ?? new T();
   }

--- a/src/Lib/JsonExtention/IJsonClass.cs
+++ b/src/Lib/JsonExtention/IJsonClass.cs
@@ -1,8 +1,0 @@
-﻿namespace JsonExtention;
-
-/// <summary>
-/// JSON継承用インターフェイス
-/// </summary>
-public interface IJsonClass
-{
-}


### PR DESCRIPTION
ジェネリクスに実装組み換えするため、インターフェイス「IJsonClass」の削除を行った。